### PR TITLE
Fixes for replaying plots

### DIFF
--- a/R/showtext.R
+++ b/R/showtext.R
@@ -334,8 +334,8 @@ showtext_auto = function(enable = TRUE)
 {
     enable = as.logical(enable)
     
-    has_hook = length(getHook("before.plot.new")) > 0
-    is_showtext_hook = sapply(getHook("before.plot.new"), identical,
+    has_hook = length(getHook("plot.new")) > 0
+    is_showtext_hook = sapply(getHook("plot.new"), identical,
                               y = showtext::showtext_begin)
     
     has_hook_grid = length(getHook("grid.newpage")) > 0
@@ -348,15 +348,15 @@ showtext_auto = function(enable = TRUE)
     if(enable)
     {
         if(!already_hooked)
-            setHook("before.plot.new", showtext::showtext_begin)
+            setHook("plot.new", showtext::showtext_begin)
         if(!already_hooked_grid)
             setHook("grid.newpage", showtext::showtext_begin)
     } else {
         if(already_hooked)
         {
-            old_hooks = getHook("before.plot.new")
+            old_hooks = getHook("plot.new")
             new_hooks = old_hooks[!is_showtext_hook]
-            setHook("before.plot.new", new_hooks, "replace")
+            setHook("plot.new", new_hooks, "replace")
         }
         if(already_hooked_grid)
         {

--- a/R/showtext.R
+++ b/R/showtext.R
@@ -242,9 +242,16 @@ showtext_begin = function()
         .pkg.env$.use_raster = FALSE
         .pkg.env$.dev_units_per_point = 1.0
     }
-
-    .Call("showtext_begin", PACKAGE = "showtext")
+    
+    grDevices::recordGraphics(
+      showtext_begin_(), as.list(.pkg.env), getNamespace("showtext")
+    )
+    
     invisible(NULL)
+}
+
+showtext_begin_ <- function() {
+  .Call("showtext_begin", PACKAGE = "showtext")
 }
 
 #' @rdname showtext_begin


### PR DESCRIPTION
Closes #39.

653640c seems sufficient for fixing the issue for grid graphics, but 13e252c also seems necessary to fix the issue for base graphics (I'm not entirely sure why the timing matters). Here's a minimal base example:

```r
library(showtext)
font_add_google("Lobster", "lobster")
showtext_auto()
png("foo.png")
dev.control(displaylist = "enable")
plot(1, pch = 16, cex = 3)
text(1, 1.1, "A fancy dot", family = "lobster", col = "steelblue", cex = 3)
result <- recordPlot()
dev.off()
file.show("foo.png")

png("foo2.png")
replayPlot(result)
dev.off()
file.show("foo2.png")
```